### PR TITLE
Optimize querying for single item user ID lists

### DIFF
--- a/extension/src/main/java/org/camunda/bpm/extension/keycloak/KeycloakUserService.java
+++ b/extension/src/main/java/org/camunda/bpm/extension/keycloak/KeycloakUserService.java
@@ -174,6 +174,8 @@ public class KeycloakUserService extends KeycloakServiceBase {
 
 			if (StringUtils.hasLength(query.getId())) {
 				response = requestUserById(query.getId());
+			} else if (query.getIds() != null && query.getIds().length == 1) {
+				response = requestUserById(query.getIds()[0]);
 			} else {
 				// Create user search filter
 				String userFilter = createUserSearchFilter(query);

--- a/extension/src/test/java/org/camunda/bpm/extension/keycloak/test/KeycloakUserQueryTest.java
+++ b/extension/src/test/java/org/camunda/bpm/extension/keycloak/test/KeycloakUserQueryTest.java
@@ -63,6 +63,10 @@ public class KeycloakUserQueryTest extends AbstractKeycloakIdentityProviderTest 
     users = identityService.createUserQuery().userIdIn("camunda@accso.de", "non-existing").list();
     assertNotNull(users);
     assertEquals(1, users.size());
+
+    users = identityService.createUserQuery().userIdIn("camunda@accso.de").list();
+    assertNotNull(users);
+    assertEquals(1, users.size());
   }
   
   public void testFilterByFirstname() {


### PR DESCRIPTION
# Camunda Keycloak Identity Provider Pull Request

## Description
When querying for a list of user IDs which only contains a single item, query the user by ID directly.

## Additional context
Requesting a single user by ID can be easily done through the Keycloak API using the user ID path variable. Searching for multiple users by a list of IDs seems not to be supported though. As a result, the Camunda Keycloak Plugin seems to ignore the list of user IDs and simply queries for all users.
In combination with caching and querying problems in Keycloak setups backed by LDAP, where Keycloak fails to cache users and also retrieves each user by a separate request, this behavior can have a significant impact on the performance, especially when using the task UI. Assigning a task or viewing an assigned task seems to generate queries that search for a list of user IDs that only contains that single ID. With increased traffic these long running queries seem to block the whole application. We have seen similar behavior to #69 and hope to fix it with this PR.

## Testing your changes
Next to debugging the application to trace the execution of single item user ID list queries I have added a unit test for this scenario.
The functionality of the `requestUserById` method should already be covered by other tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [ ] My pull request requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation
- [x] I have read the **Pull Request Process** documentation
- [x] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @celanthe in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's Maintainer
